### PR TITLE
Make based-connect work with QC35 Series 2 and new firmware

### DIFF
--- a/based.c
+++ b/based.c
@@ -320,9 +320,7 @@ int get_device_status(int sock, char name[MAX_NAME_LEN + 1], enum PromptLanguage
 		*level = NC_DNE;
 	}
 
-	static const uint8_t ack2[] = { 0x01, 0x01, 0x06, 0x00 };
-	uint8_t buffer2[sizeof(ack2)];
-	return read_check(sock, buffer2, sizeof(buffer2), ack2, NULL);
+	return status;
 }
 
 int set_pairing(int sock, enum Pairing pairing) {

--- a/based.c
+++ b/based.c
@@ -331,6 +331,16 @@ int set_pairing(int sock, enum Pairing pairing) {
 	return write_check(sock, send, sizeof(send), ack, sizeof(ack));
 }
 
+int set_self_voice(int sock, enum SelfVoice selfvoice) {
+	static uint8_t send[] = { 0x01, 0x0b, 0x02, 0x02, 0x01, ANY, 0x38 };
+	static uint8_t ack[] = { 0x01, 0x0b, 0x03, 0x03, 0x01, ANY, 0x0f};
+
+	send[5] = selfvoice;
+	ack[5] = selfvoice;
+	return write_check(sock, send, sizeof(send), ack, sizeof(ack));
+}
+
+
 int get_firmware_version(int sock, char version[VER_STR_LEN]) {
 	static const uint8_t send[] = { 0x00, 0x05, 0x01, 0x00 };
 	static const uint8_t ack[] = { 0x00, 0x05, 0x03, 0x05 };

--- a/based.h
+++ b/based.h
@@ -63,6 +63,13 @@ enum DevicesConnected {
 	DC_TWO = 0x03
 };
 
+enum SelfVoice {
+	SV_OFF = 0x0,
+	SV_HIGH = 0x1,
+	SV_MEDIUM = 0x2,
+	SV_LOW = 0x3,
+};
+
 struct Device {
 	bdaddr_t address;
 	enum DeviceStatus status;
@@ -81,6 +88,7 @@ int set_noise_cancelling(int sock, enum NoiseCancelling level);
 int get_device_status(int sock, char name[MAX_NAME_LEN + 1], enum PromptLanguage *language,
 		enum AutoOff *minutes, enum NoiseCancelling *level);
 int set_pairing(int sock, enum Pairing pairing);
+int set_self_voice(int sock, enum SelfVoice selfVoice);
 int get_firmware_version(int sock, char version[VER_STR_LEN]);
 int get_serial_number(int sock, char serial[0x100]);
 int get_battery_level(int sock, unsigned int *level);

--- a/based.h
+++ b/based.h
@@ -11,7 +11,7 @@
 #define MAX_NUM_DEVICES 8
 #define MAX_BT_PACK_LEN 0x1000
 #define VER_STR_LEN 6
-#define VP_MASK 0x20
+#define VP_MASK 0x7F
 
 enum NoiseCancelling {
 	NC_HIGH = 0x01,
@@ -38,9 +38,13 @@ enum PromptLanguage {
 	PL_PT = 0x27,
 	PL_ZH = 0x28,
 	PL_KO = 0x29,
+	PL_PL = 0x2B,
+	PL_RU = 0x2A,
 	PL_NL = 0x2e,
 	PL_JA = 0x2f,
 	PL_SV = 0x32
+	
+
 };
 
 enum Pairing {

--- a/main.c
+++ b/main.c
@@ -89,7 +89,11 @@ static int do_set_prompt_language(int sock, const char *arg) {
 		pl = PL_ZH;
 	} else if (strcmp(arg, "ko") == 0) {
 		pl = PL_KO;
-	} else if (strcmp(arg, "nl") == 0) {
+	} else if (strcmp(arg, "pl") == 0) {
+		pl = PL_PL;
+	} else if (strcmp(arg, "ru") == 0) {
+		pl = PL_RU;
+	}  else if (strcmp(arg, "nl") == 0) {
 		pl = PL_NL;
 	} else if (strcmp(arg, "ja") == 0) {
 		pl = PL_JA;
@@ -191,7 +195,7 @@ static int do_get_device_status(int sock) {
 	char *print;
 	printf("Name: %s\n", name);
 
-	switch (pl | VP_MASK) {
+	switch (pl & VP_MASK) {
 		case PL_EN:
 			print = "en";
 			break;
@@ -225,8 +229,15 @@ static int do_get_device_status(int sock) {
 		case PL_SV:
 			print = "sv";
 			break;
+		case PL_RU:
+			print = "ru";
+			break;
+		case PL_PL:
+			print = "pl";
+			break;
 		default:
-			return 1;
+			print = "unknown";
+			break;
 	}
 	printf("Language: %s\n", print);
 	printf("Voice Prompts: %s\n", pl & VP_MASK ? "on" : "off");

--- a/main.c
+++ b/main.c
@@ -53,6 +53,9 @@ static void usage() {
 		"\t\tRemove the device at address from the pairing list.\n"
 		"\t--device-id\n"
 		"\t\tPrint the device id followed by the index revision.\n"
+		"\t-e, --self-voice\n"
+		"\t\tChange the self voice level.\n"
+		"\t\tlevel: high, medium, low, off\n"
 		, program_name);
 }
 
@@ -286,6 +289,26 @@ static int do_set_pairing(int sock, const char *arg) {
 	return set_pairing(sock, p);
 }
 
+static int do_set_self_voice(int sock, const char *arg) {
+	enum SelfVoice p;
+
+	if (strcmp(arg, "high") == 0) {
+		p = SV_HIGH;
+	} else if (strcmp(arg, "medium") == 0) {
+		p = SV_MEDIUM;
+	} else if (strcmp(arg, "low") == 0) {
+		p = SV_LOW;
+	} else if (strcmp(arg, "off") == 0) {
+		p = SV_OFF;
+	} else {
+		fprintf(stderr, "Invalid self voice argument: %s\n", arg);
+		usage();
+		return 1;
+	}
+
+	return set_self_voice(sock, p);
+}
+
 static int do_get_firmware_version(int sock) {
 	char version[VER_STR_LEN];
 	int status = get_firmware_version(sock, version);
@@ -431,7 +454,7 @@ static int do_send_packet(int sock, const char *arg) {
 }
 
 int main(int argc, char *argv[]) {
-	static const char *short_opt = "hn:l:v:o:c:dp:fsba";
+	static const char *short_opt = "hn:l:v:o:c:e:dp:fsba";
 	static const struct option long_opt[] = {
 		{ "help", no_argument, NULL, 'h' },
 		{ "name", required_argument, NULL, 'n' },
@@ -449,6 +472,7 @@ int main(int argc, char *argv[]) {
 		{ "disconnect-device", required_argument, NULL, 3 },
 		{ "remove-device", required_argument, NULL, 4 },
 		{ "device-id", no_argument, NULL, 5 },
+		{ "self-voice", required_argument, NULL, 'e' },
 		{ "send-packet", required_argument, NULL, 1 },
 		{ 0, 0, 0, 0 }
 	};
@@ -545,6 +569,9 @@ int main(int argc, char *argv[]) {
 				break;
 			case 'a':
 				status = do_get_paired_devices(sock);
+				break;
+			case 'e':
+				status = do_set_self_voice(sock, optarg);
 				break;
 			case 2:
 				status = do_connect_device(sock, optarg);


### PR DESCRIPTION
Tested with firmware 4.8.1 and QC35 Series 2:

- Add newly supported languages
- Make language readout work
- Make setting Self voice to different levels work

No idea if this also works on older firmware / devices.